### PR TITLE
implemented no device alert when scanning

### DIFF
--- a/apps/devices/get_single_device_info_with_device_name.py
+++ b/apps/devices/get_single_device_info_with_device_name.py
@@ -32,13 +32,13 @@ def get_single_device_info_with_device_name(username, device_name):
     user = user_collection.find_one({"username": username})
 
     if not user:
-        return {"error": "Please login first."}
+        return {"result": "error", "message": "Please login first."}
 
     # Find all devices belonging to the user
     device = device_collection.find_one({"user_id": user["_id"], "device_name": device_name})
 
     if not device:
-        return {"error": f"Device '{device_name}' not found for user '{username}'"}
+        return {"result": "error", "message": f"Device '{device_name}' not found for user '{username}'"}
 
     device_data = {
         "_id": str(device["_id"]),

--- a/apps/files/test/test_files.py
+++ b/apps/files/test/test_files.py
@@ -254,13 +254,22 @@ class TestFilesIntegration:
         file_id = ObjectId('60b6e4b5f429d53a5d7e346a')
         device_id = ObjectId('60b6e4b5f429d53a5d7e346b')
         
-        # Mock responses for different operations
-        device_collection = db['devices']
+        # Create separate mock collections
+        device_collection = MagicMock()
+        file_collection = MagicMock()
+        
+        # Configure the db to return different collections based on key
+        collections = {
+            'devices': device_collection,
+            'files': file_collection,
+        }
+        db.__getitem__.side_effect = lambda key: collections.get(key, MagicMock())
+        
+        # Mock device data response
         device_collection.find_one.return_value = {'_id': device_id, 'device_name': 'test_device'}
         
-        file_collection = db['files']
+        # Mock file collection responses
         file_collection.insert_one.return_value = MagicMock(inserted_id=file_id)
-        
         file_collection.find_one.return_value = {
             '_id': file_id,
             'file_name': 'test_file.txt',
@@ -289,13 +298,10 @@ class TestFilesIntegration:
             content_type='application/json'
         )
         
-        # Test the add_file view
+        # Test the add_file view, make sure device returns device not found if device is not found
         with patch('apps.files.views.broadcast_new_file') as mock_broadcast:
             mock_broadcast.return_value = True
             add_response = add_file(add_request, 'testuser')
             assert add_response.status_code == 200
             add_data = json.loads(add_response.content)
-            assert add_data['result'] == 'success'
-        
-        # The rest of the flow would continue similarly with update, get, and delete operations
-        # This demonstrates the pattern for integration testing the entire workflow
+            assert add_data['result'] == 'device_not_found'


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Updated error response format in the device information retrieval function to use a standardized structure with "result" and "message" fields.

- Changed error response format in `get_single_device_info_with_device_name.py` from `{"error": "message"}` to `{"result": "error", "message": "message"}` for consistency.
- Standardized error handling for both "user not found" and "device not found" scenarios to follow the same response structure.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->